### PR TITLE
fixes

### DIFF
--- a/httpClient.cpp
+++ b/httpClient.cpp
@@ -42,6 +42,7 @@ int main()
         std::istringstream iss(inputLine);  // Split the input
         iss >> serverAddress;               // First word = server address
         std::getline(iss, fileName);        // Rest = file name
+        fileName.erase(0,1);                // remove the space from the front of the file name
 
 
         // Create the socket
@@ -63,7 +64,7 @@ int main()
         // Convert the user-inputted IP address from string to binary
         if (inet_pton(AF_INET, serverAddress.c_str(), &servAddress.sin_addr) <= 0)
         {
-            perror("Invalid address/Address not supported.");
+            std::cout << "Invalid address/Address not supported.\n\n";
             close(clientSocket);
             continue; // Skip and allow the user to enter another request
         }
@@ -72,18 +73,20 @@ int main()
         // Params: which socket, cast for server address, its size
         if (connect(clientSocket, (struct sockaddr *)&servAddress, sizeof(servAddress)) == -1)
         {
-            perror("Connection failed.");
+            std::cout << "Server did not respond...\n\n"; 
             close(clientSocket);
             continue;
         }
 
         std::ostringstream reqStream;
+
         reqStream << "GET /" << fileName << " HTTP/1.1\r\n"
                   << "host: localhost\r\n"
                   << "Connection: close\r\n"
                   << "\r\n";
 
         std::string httpReq = reqStream.str();
+
 
         send(clientSocket, httpReq.c_str(), httpReq.size(), 0);
 

--- a/httpServer.cpp
+++ b/httpServer.cpp
@@ -182,7 +182,7 @@ int main()
                           << fileContent;
                 std::string httpRes = resStream.str();
                 send(clientSocket, httpRes.c_str(), httpRes.size(), 0);
-                std::cout << "Server response: " << httpRes << std::endl;
+               // std::cout << "Server response: " << httpRes << std::endl;
             }
             else // file path choosen is not valid, send "404 not found"
             {


### PR DESCRIPTION
Made some needed fixes to the client. 

Users are not able to specify the file they would like to be served as well as the address of the server.

I also added in handling if the ip address specified is unreachable, as well as if the ip address is reachable but not taking request (basically if the server program was terminated).

I believe all that is left is maybe error checking if the user inputted an IP and a file. As of now we do not check for that.